### PR TITLE
Fix social links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 - 👀 I’m interested in Python, Full Stack Web Development and Automation
 - 🌱 I’m currently learning Full Stack Web Development
 - 💞️ I’m looking to collaborate on Web Development projects and fun school-type python projects
-- 📫 Instagram: __bihari___ LinkedIn: Neelay Naman
+- 📫 Instagram: [\_\_bihari___](https://www.instagram.com/__bihari___/) , LinkedIn: [Neelay Naman](https://www.linkedin.com/in/neelay-naman/)


### PR DESCRIPTION
## This patch fixes social links.

In Markdown, use `[name](URL)` format to add hyperlinks. You're more likely to get profile visits if you add links instead of usernames.

Also, your Instagram username was broken because markdown was parsing the underscores as formatting specifiers. You have to escape them with backslashes (`\`)